### PR TITLE
Initialize SupermarketBot with basic CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
 # supermarketBot
+
+A simple command line supermarket assistant that lets you manage a small shopping cart. Use it to add or remove items and display the total amount.
+
+## Running the bot
+
+```bash
+python3 -m supermarket_bot
+```
+
+You will be presented with a menu to add items, remove items, list the cart contents and show the total price.
+
+## Building a Mercadona product dataset
+
+You can fetch all available products and prices from the public Mercadona API and
+store them in a CSV file:
+
+```bash
+python3 -m supermarket_bot.dataset products.csv
+```
+
+## Running tests
+
+```bash
+python3 -m unittest
+```

--- a/supermarket_bot/__init__.py
+++ b/supermarket_bot/__init__.py
@@ -1,0 +1,60 @@
+__all__ = ["SupermarketBot"]
+
+class SupermarketBot:
+    """A simple in-memory shopping cart."""
+
+    def __init__(self):
+        self.items = {}
+
+    def add_item(self, name, price):
+        if price < 0:
+            raise ValueError("price can't be negative")
+        self.items[name] = price
+
+    def remove_item(self, name):
+        if name not in self.items:
+            raise KeyError(name)
+        del self.items[name]
+
+    def total(self):
+        return sum(self.items.values())
+
+    def list_items(self):
+        return list(self.items.items())
+
+
+def main():
+    bot = SupermarketBot()
+    menu = (
+        "\n1) Add item\n" "2) Remove item\n" "3) Show total\n" "4) List items\n" "5) Exit\n"
+    )
+    while True:
+        choice = input(menu + "Select an option: ")
+        if choice == "1":
+            name = input("Item name: ")
+            price = float(input("Price: "))
+            try:
+                bot.add_item(name, price)
+                print(f"Added {name} for {price:.2f}")
+            except ValueError as exc:
+                print(exc)
+        elif choice == "2":
+            name = input("Item name to remove: ")
+            try:
+                bot.remove_item(name)
+                print(f"Removed {name}")
+            except KeyError:
+                print("Item not found")
+        elif choice == "3":
+            print(f"Total: {bot.total():.2f}")
+        elif choice == "4":
+            for name, price in bot.list_items():
+                print(f"{name}: {price:.2f}")
+        elif choice == "5":
+            break
+        else:
+            print("Invalid choice")
+
+
+if __name__ == "__main__":
+    main()

--- a/supermarket_bot/dataset.py
+++ b/supermarket_bot/dataset.py
@@ -1,0 +1,64 @@
+import csv
+from typing import Iterable, Dict, Set
+import requests
+
+BASE_URL = "https://tienda.mercadona.es/api"
+
+
+def _get_json(path: str) -> Dict:
+    url = f"{BASE_URL}{path}"
+    resp = requests.get(url)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _fetch_category(cat_id: int) -> Dict:
+    return _get_json(f"/categories/{cat_id}/")
+
+
+def _root_categories() -> Iterable[int]:
+    data = _get_json("/categories/")
+    for cat in data.get("results", []):
+        yield cat["id"]
+
+
+def iter_products() -> Iterable[Dict]:
+    """Yield all products available in the Mercadona API."""
+    seen: Set[int] = set()
+    queue = list(_root_categories())
+    while queue:
+        cid = queue.pop()
+        if cid in seen:
+            continue
+        seen.add(cid)
+        cat = _fetch_category(cid)
+        for prod in cat.get("products", []):
+            yield prod
+        for sub in cat.get("categories", []):
+            for prod in sub.get("products", []):
+                yield prod
+            if isinstance(sub, dict) and "id" in sub and sub["id"] not in seen:
+                queue.append(sub["id"])
+
+
+def build_dataset(csv_path: str) -> None:
+    """Fetch all products and write them to a CSV file."""
+    with open(csv_path, "w", newline="", encoding="utf-8") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["id", "name", "price"])
+        for prod in iter_products():
+            price = prod.get("price_instructions", {}).get("unit_price")
+            writer.writerow([prod.get("id"), prod.get("display_name"), price])
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Fetch Mercadona product dataset")
+    parser.add_argument("output", help="path to output CSV file")
+    args = parser.parse_args(list(argv) if argv is not None else None)
+    build_dataset(args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1,0 +1,29 @@
+import unittest
+from supermarket_bot import SupermarketBot
+
+
+class TestSupermarketBot(unittest.TestCase):
+    def setUp(self):
+        self.bot = SupermarketBot()
+
+    def test_add_and_total(self):
+        self.bot.add_item('apple', 1.0)
+        self.bot.add_item('banana', 2.5)
+        self.assertEqual(self.bot.total(), 3.5)
+
+    def test_remove_item(self):
+        self.bot.add_item('milk', 1.2)
+        self.bot.remove_item('milk')
+        self.assertEqual(self.bot.total(), 0)
+
+    def test_remove_missing_item_raises(self):
+        with self.assertRaises(KeyError):
+            self.bot.remove_item('missing')
+
+    def test_add_negative_price_raises(self):
+        with self.assertRaises(ValueError):
+            self.bot.add_item('bad', -1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,0 +1,45 @@
+import unittest
+from unittest import mock
+
+from supermarket_bot import dataset
+
+class TestDataset(unittest.TestCase):
+    def test_iter_products(self):
+        root_data = {"results": [{"id": 1}]}
+        cat1_data = {
+            "products": [],
+            "categories": [
+                {
+                    "id": 2,
+                    "products": [
+                        {
+                            "id": "p1",
+                            "display_name": "Item1",
+                            "price_instructions": {"unit_price": "1.00"},
+                        }
+                    ],
+                }
+            ],
+        }
+        responses = {
+            f"{dataset.BASE_URL}/categories/": root_data,
+            f"{dataset.BASE_URL}/categories/1/": cat1_data,
+            f"{dataset.BASE_URL}/categories/2/": {"products": []},
+        }
+
+        def fake_get(url, *args, **kwargs):
+            data = responses.get(url)
+            if data is None:
+                raise AssertionError(f"Unexpected URL: {url}")
+            m = mock.Mock()
+            m.status_code = 200
+            m.json.return_value = data
+            return m
+
+        with mock.patch("supermarket_bot.dataset.requests.get", side_effect=fake_get):
+            items = list(dataset.iter_products())
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0]["id"], "p1")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a `SupermarketBot` module with a simple interactive CLI
- document how to run the bot and the tests
- provide unit tests for basic cart behavior
- add dataset downloader to fetch products from the Mercadona API

## Testing
- `python3 -m unittest -v`


------
https://chatgpt.com/codex/tasks/task_e_6840a831cac0832fb61a95f340aa1cb2